### PR TITLE
fix(nuenv): use nu-recommended way of stdin

### DIFF
--- a/nix/my/nuenv.nix
+++ b/nix/my/nuenv.nix
@@ -118,6 +118,12 @@ rec {
       */
       derivationArgs ? { },
       nushell ? pkgs.nushell,
+      /*
+        Whether to allow the script to have access to stdin
+
+        Type: bool
+      */
+      useStdin ? true,
     }:
     pkgs.writeTextFile {
       inherit name meta derivationArgs;
@@ -127,7 +133,7 @@ rec {
       preferLocalBuild = false;
       tet =
         ''
-          #!${nushell}/bin/nu
+          #!/usr/bin/env -S ${(lib.getExe nushell) + lib.optionalString useStdin " --stdin"}
         ''
         + lib.optionalString (runtimeEnv != null) ''
 

--- a/nix/my/nuenv.nix
+++ b/nix/my/nuenv.nix
@@ -119,11 +119,13 @@ rec {
       derivationArgs ? { },
       nushell ? pkgs.nushell,
       /*
-        Whether to allow the script to have access to stdin
+        Extra arguments to pass into nushell invoker
+        Defaults to allowing stdin with "--stdin".
+        See all arguments with `nu --help`
 
-        Type: bool
+        Type: [String]
       */
-      useStdin ? true,
+      nushellArgs ? [ "--stdin" ],
     }:
     pkgs.writeTextFile {
       inherit name meta derivationArgs;
@@ -133,7 +135,7 @@ rec {
       preferLocalBuild = false;
       tet =
         ''
-          #!/usr/bin/env -S ${(lib.getExe nushell) + lib.optionalString useStdin " --stdin"}
+          #!/usr/bin/env -S ${lib.concatStringsSep " " ([ (lib.getExe nushell) ] ++ nushellArgs)}
         ''
         + lib.optionalString (runtimeEnv != null) ''
 


### PR DESCRIPTION
Thank you for making your code public. I have been using this for many months. However, it does not work in this edge case in my git config:
```nix
# a home-manager git module
programs.git.extraConfig.filter.testFilter = {
  smudge = "cat";
  clean = lib.getExe (writeNuApplication {
    name = "simple-nu-test";
    text = # nu
      ''
        def main [] {
          echo $"stdin: ($in)"
        }
      '';
  });
```

When I run `git diff`, the right hand side, the changed/cleaned file is just "stdin: ". When I apply this PR change, the diff is corrected!

Attempting to use this with git clean/smudge scripts will not work
without this change. After this change, they will work properly.

Source:
https://www.nushell.sh/book/scripts.html#shebangs


--- 

In my second commit, I enhance the change to allow arbitrary command line interpreter additions :D.